### PR TITLE
replaces "lastModifiedDate" with "lastModified"

### DIFF
--- a/src/js/imdi_resources.js
+++ b/src/js/imdi_resources.js
@@ -405,7 +405,7 @@ imdi_environment.workflow[1] = (function(){
 				name: f.name,
 				mime_type: f.type || 'n/a',
 				size: strings.bytesToSize(f.size,1),
-				lastModified: f.lastModifiedDate.toLocaleDateString()
+				lastModified: f.lastModified
 			});
 		}
 		


### PR DESCRIPTION
"lastModifiedDate" is no longer supported by Firefox (see: https://developer.mozilla.org/en-US/docs/Web/API/File/lastModifiedDate#Specifications) and caused a bug preventing users from importing resources. Replacing it with simply "lastModified" fixes this.